### PR TITLE
feat: 캘린더 화면 UI 및 BottomNav 네비게이션 구현

### DIFF
--- a/.claude/agents/ui-implementor.md
+++ b/.claude/agents/ui-implementor.md
@@ -115,9 +115,26 @@ lib/
 **파일**: `lib/shared/widgets/app_bottom_nav_bar.dart`
 - Todo, Calendar, My 3개 화면에서 공유 → `shared/widgets/`에 배치
 - 파라미터: `currentIndex`, `onTap`
-- 탭 구성: `Calendar` | `To Do` | `My`
+- 탭 구성 (인덱스 고정): `0: Calendar` | `1: To Do` | `2: My`
 - 활성 탭: `#512DA8` 배경 + 흰 텍스트
 - 비활성 탭: 기본 텍스트
+
+#### 탭 → 화면 매핑
+
+| 인덱스 | 라벨 | 이동 대상 화면 | 파일 |
+|--------|------|----------------|------|
+| 0 | Calendar | `CalendarScreen` | `lib/features/calendar/view/calendar_screen.dart` |
+| 1 | To Do | `TodoScreen` | `lib/features/todo/view/todo_screen.dart` |
+| 2 | My | `MyScreen` | `lib/features/profile/view/my_screen.dart` |
+
+#### 네비게이션 동작 규칙
+
+- 현재 화면과 동일한 탭을 다시 탭한 경우: **무시** (no-op).
+- 다른 탭으로 이동: 백 스택을 쌓지 않도록 **화면 전환(replace)** 방식 사용.
+  - go_router 도입 전: `Navigator.pushReplacement(MaterialPageRoute)`
+  - go_router 도입 후: `context.go('/calendar' | '/todo' | '/my')`
+- 이동 직후 새 화면의 BottomNavigationBar `currentIndex`는 해당 탭을 활성 상태로 유지한다.
+- My 탭(`MyScreen`)이 아직 미구현인 경우: 코드 단에서는 `// TODO(my-page)` 주석으로 자리만 두고 실제 네비게이션은 비워둔다. 단, 스펙상 위 매핑은 확정값이므로 이후 구현 시 위 표를 따른다.
 
 ---
 

--- a/.claude/agents/ui-implementor/02_todo.md
+++ b/.claude/agents/ui-implementor/02_todo.md
@@ -44,6 +44,18 @@ Scaffold (bg: #f3f4eb)
   - 그 외 상태에서는 `Visibility(maintainSize: true)`로 자리만 유지하고 숨김 → 행 너비 일정
 - `TextField`: `maxLength: 20`, `hintText: "목표를 입력해주세요"`
 
+## BottomNavigationBar 동작
+
+- `currentIndex = 1` (To Do 활성).
+- 탭별 이동:
+  | 인덱스 | 라벨 | 동작 |
+  |--------|------|------|
+  | 0 | Calendar | `CalendarScreen`으로 화면 전환 (replace) |
+  | 1 | To Do | 현재 화면 — no-op |
+  | 2 | My | `MyScreen`으로 화면 전환 (replace) — 미구현 시 `// TODO(my-page)` 주석 |
+- go_router 도입 전: `Navigator.pushReplacement(MaterialPageRoute(builder: (_) => const CalendarScreen()))`.
+- 공통 규칙은 `.claude/agents/ui-implementor.md` `공유 위젯: BottomNavigationBar` 절 참고.
+
 ## v1.0.0 결정사항
 
 - 달성 시 목록 숨김 없음 (달성해도 계속 표시) ※ 와이어프레임(todo-02)에서는 숨김처리로 표시되나, v1.0.0에서 보류됨 — 스펙 우선

--- a/.claude/agents/ui-implementor/03_calendar.md
+++ b/.claude/agents/ui-implementor/03_calendar.md
@@ -49,6 +49,18 @@ Scaffold (bg: #f3f4eb)
 - 최소 월: `DateTime(2026, 4)` → 좌측 버튼 `onPressed: null`
 - 우측 버튼: 항상 활성
 
+## BottomNavigationBar 동작
+
+- `currentIndex = 0` (Calendar 활성).
+- 탭별 이동:
+  | 인덱스 | 라벨 | 동작 |
+  |--------|------|------|
+  | 0 | Calendar | 현재 화면 — no-op |
+  | 1 | To Do | `TodoScreen`으로 화면 전환 (replace) |
+  | 2 | My | `MyScreen`으로 화면 전환 (replace) — 미구현 시 `// TODO(my-page)` 주석 |
+- go_router 도입 전: `Navigator.pushReplacement(MaterialPageRoute(builder: (_) => const TodoScreen()))`.
+- 공통 규칙은 `.claude/agents/ui-implementor.md` `공유 위젯: BottomNavigationBar` 절 참고.
+
 ## ? 버튼 팝업
 
 - 탭 시 `showDialog(AlertDialog)` 표시

--- a/.claude/agents/ui-implementor/04_mypage.md
+++ b/.claude/agents/ui-implementor/04_mypage.md
@@ -31,6 +31,18 @@ Scaffold (bg: #f3f4eb)
   - 타이틀: "탈퇴하시겠습니까?"
   - 버튼: "취소" (닫기) / "확인" (onConfirm 콜백)
 
+### BottomNavigationBar 동작
+
+- `currentIndex = 2` (My 활성).
+- 탭별 이동:
+  | 인덱스 | 라벨 | 동작 |
+  |--------|------|------|
+  | 0 | Calendar | `CalendarScreen`으로 화면 전환 (replace) |
+  | 1 | To Do | `TodoScreen`으로 화면 전환 (replace) |
+  | 2 | My | 현재 화면 — no-op |
+- go_router 도입 전: `Navigator.pushReplacement(MaterialPageRoute(builder: (_) => const CalendarScreen()))`.
+- 공통 규칙은 `.claude/agents/ui-implementor.md` `공유 위젯: BottomNavigationBar` 절 참고.
+
 ---
 
 ## 프로필 편집 화면

--- a/.claude/ui/v1.0.0/02_todo화면.md
+++ b/.claude/ui/v1.0.0/02_todo화면.md
@@ -70,6 +70,13 @@
 | To Do | `#512DA8` 배경 + 흰 텍스트 | 기본 텍스트 |
 | My | - | 기본 텍스트 |
 
+#### 탭 동작
+- `currentIndex = 1` (To Do 활성).
+- `0: Calendar` 탭 → `CalendarScreen`으로 화면 전환 (replace).
+- `1: To Do` 탭 → 현재 화면, no-op.
+- `2: My` 탭 → `MyScreen`으로 화면 전환 (replace). MyScreen 미구현 시 코드 단에서 `// TODO(my-page)` 주석.
+- go_router 도입 전: `Navigator.pushReplacement(MaterialPageRoute)`.
+
 ---
 
 ## 구현 계획

--- a/.claude/ui/v1.0.0/03_캘린더화면.md
+++ b/.claude/ui/v1.0.0/03_캘린더화면.md
@@ -62,6 +62,13 @@
 - `Row`로 구성: `[● 빨강 N] [● 노랑 N] [● 초록 N] [● 파랑 N]`
 - 각 항목: 해당 색상 원형 + 해당 월에 해당 스티커가 붙은 날짜 수
 
+### BottomNavigationBar 탭 동작
+- `currentIndex = 0` (Calendar 활성).
+- `0: Calendar` 탭 → 현재 화면, no-op.
+- `1: To Do` 탭 → `TodoScreen`으로 화면 전환 (replace).
+- `2: My` 탭 → `MyScreen`으로 화면 전환 (replace). MyScreen 미구현 시 코드 단에서 `// TODO(my-page)` 주석.
+- go_router 도입 전: `Navigator.pushReplacement(MaterialPageRoute)`.
+
 ### ? 버튼 팝업 (스티커 안내)
 - 트리거: 탭 (모바일 환경, 호버 없음)
 - 팝업 구성: 보라색 계열 배경 카드 + 스티커 색상별 달성률 범위 설명

--- a/.claude/ui/v1.0.0/04_마이페이지화면.md
+++ b/.claude/ui/v1.0.0/04_마이페이지화면.md
@@ -28,6 +28,13 @@
 | `AlertDialog` | 회원탈퇴 확인 팝업 |
 | `BottomNavigationBar` | 탭 네비게이션 |
 
+### BottomNavigationBar 탭 동작
+- `currentIndex = 2` (My 활성).
+- `0: Calendar` 탭 → `CalendarScreen`으로 화면 전환 (replace).
+- `1: To Do` 탭 → `TodoScreen`으로 화면 전환 (replace).
+- `2: My` 탭 → 현재 화면, no-op.
+- go_router 도입 전: `Navigator.pushReplacement(MaterialPageRoute)`.
+
 ---
 
 ## 프로필 편집 화면

--- a/lib/features/calendar/view/calendar_screen.dart
+++ b/lib/features/calendar/view/calendar_screen.dart
@@ -1,0 +1,410 @@
+import 'package:flutter/material.dart';
+
+import '../../../shared/widgets/calendar_grid.dart';
+
+/// 캘린더 화면.
+///
+/// 레이아웃:
+/// Scaffold → SafeArea → Stack
+///   ├─ Column
+///   │  ├─ 월 네비게이션 헤더 (YYYY / ◀ MMMM ▶)
+///   │  ├─ 달성률 범례 바 (● N × 4)
+///   │  ├─ 요일 헤더 (SUN ~ SAT)
+///   │  └─ Expanded → CalendarGrid
+///   └─ Positioned(top, right) → ? 버튼 (스티커 안내 팝업)
+///
+/// 월 이동 규칙:
+/// - 최소 월: 2026년 4월 → 좌측 화살표 비활성
+/// - 우측 화살표: 항상 활성
+///
+/// MVP UI 단계 — 달성률 데이터는 빈 Map으로 초기화한다.
+/// ViewModel / Repository 연결은 후속 작업에서 진행.
+class CalendarScreen extends StatefulWidget {
+  const CalendarScreen({super.key});
+
+  @override
+  State<CalendarScreen> createState() => _CalendarScreenState();
+}
+
+class _CalendarScreenState extends State<CalendarScreen> {
+  static const Color _primary = Color(0xFF512DA8);
+  static const Color _bg = Color(0xFFF3F4EB);
+  static final DateTime _minMonth = DateTime(2026, 4);
+
+  static const List<String> _monthNames = <String>[
+    'JANUARY',
+    'FEBRUARY',
+    'MARCH',
+    'APRIL',
+    'MAY',
+    'JUNE',
+    'JULY',
+    'AUGUST',
+    'SEPTEMBER',
+    'OCTOBER',
+    'NOVEMBER',
+    'DECEMBER',
+  ];
+
+  static const List<String> _weekdayLabels = <String>[
+    'SUN',
+    'MON',
+    'TUE',
+    'WED',
+    'THU',
+    'FRI',
+    'SAT',
+  ];
+
+  /// 현재 화면이 표시하는 달 (해당 월의 1일).
+  DateTime _displayMonth = DateTime(DateTime.now().year, DateTime.now().month);
+
+  /// 오늘 날짜.
+  final DateTime _today = DateTime.now();
+
+  /// 일자(`day`)별 달성률. ViewModel 연결 전까지 빈 Map.
+  final Map<int, double> _achievementRates = <int, double>{};
+
+  /// 현재 선택된 BottomNavigation 인덱스 (0: Calendar, 1: To Do, 2: My)
+  int _currentTabIndex = 0;
+
+  bool get _canGoPrev => _displayMonth.isAfter(_minMonth);
+
+  void _goPrev() {
+    if (!_canGoPrev) return;
+    setState(() {
+      _displayMonth = DateTime(_displayMonth.year, _displayMonth.month - 1);
+    });
+  }
+
+  void _goNext() {
+    setState(() {
+      _displayMonth = DateTime(_displayMonth.year, _displayMonth.month + 1);
+    });
+  }
+
+  /// 색상별 스티커가 붙은 날짜 수 집계.
+  ({int red, int yellow, int green, int blue}) _countByColor() {
+    int red = 0;
+    int yellow = 0;
+    int green = 0;
+    int blue = 0;
+    final int daysInMonth =
+        DateTime(_displayMonth.year, _displayMonth.month + 1, 0).day;
+    for (int day = 1; day <= daysInMonth; day++) {
+      final double rate = _achievementRates[day] ?? 0;
+      if (rate <= 0) continue;
+      if (rate < 0.30) {
+        red++;
+      } else if (rate < 0.60) {
+        yellow++;
+      } else if (rate < 1.00) {
+        green++;
+      } else {
+        blue++;
+      }
+    }
+    return (red: red, yellow: yellow, green: green, blue: blue);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: _bg,
+      body: SafeArea(
+        child: Stack(
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 24, 20, 12),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  _buildMonthHeader(),
+                  const SizedBox(height: 16),
+                  _buildLegendBar(),
+                  const SizedBox(height: 20),
+                  _buildWeekdayHeader(),
+                  const SizedBox(height: 4),
+                  Expanded(
+                    child: CalendarGrid(
+                      displayMonth: _displayMonth,
+                      today: _today,
+                      achievementRates: _achievementRates,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Positioned(
+              top: 12,
+              right: 16,
+              child: _buildHelpButton(),
+            ),
+          ],
+        ),
+      ),
+      bottomNavigationBar: _buildBottomNav(),
+    );
+  }
+
+  // ────────────────────── 월 네비게이션 헤더 ──────────────────────
+  Widget _buildMonthHeader() {
+    return Column(
+      children: <Widget>[
+        Text(
+          '${_displayMonth.year}',
+          style: const TextStyle(
+            fontSize: 22,
+            fontWeight: FontWeight.w700,
+            color: _primary,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            IconButton(
+              onPressed: _canGoPrev ? _goPrev : null,
+              icon: const Icon(Icons.arrow_left),
+              iconSize: 36,
+              color: _primary,
+              disabledColor: const Color(0xFFBDB0DC),
+              padding: EdgeInsets.zero,
+              constraints: const BoxConstraints(),
+            ),
+            const SizedBox(width: 16),
+            SizedBox(
+              width: 160,
+              child: Text(
+                _monthNames[_displayMonth.month - 1],
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  fontSize: 24,
+                  fontWeight: FontWeight.w700,
+                  color: _primary,
+                ),
+              ),
+            ),
+            const SizedBox(width: 16),
+            IconButton(
+              onPressed: _goNext,
+              icon: const Icon(Icons.arrow_right),
+              iconSize: 36,
+              color: _primary,
+              padding: EdgeInsets.zero,
+              constraints: const BoxConstraints(),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  // ────────────────────── 달성률 범례 바 ──────────────────────
+  Widget _buildLegendBar() {
+    final ({int red, int yellow, int green, int blue}) counts = _countByColor();
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      children: <Widget>[
+        _legendItem(const Color(0xFFE32910), counts.red),
+        _legendItem(const Color(0xFFFFC943), counts.yellow),
+        _legendItem(const Color(0xFF13D62D), counts.green),
+        _legendItem(const Color(0xFF46C8FF), counts.blue),
+      ],
+    );
+  }
+
+  Widget _legendItem(Color color, int count) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        Container(
+          width: 12,
+          height: 12,
+          decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+        ),
+        const SizedBox(width: 6),
+        Text(
+          '$count',
+          style: const TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+            color: Color(0xFF333333),
+          ),
+        ),
+      ],
+    );
+  }
+
+  // ────────────────────── 요일 헤더 ──────────────────────
+  Widget _buildWeekdayHeader() {
+    return Row(
+      children: _weekdayLabels
+          .map(
+            (String label) => Expanded(
+              child: Text(
+                label,
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: _primary,
+                ),
+              ),
+            ),
+          )
+          .toList(),
+    );
+  }
+
+  // ────────────────────── ? 버튼 + 안내 팝업 ──────────────────────
+  Widget _buildHelpButton() {
+    return GestureDetector(
+      onTap: _showStickerGuide,
+      child: Container(
+        width: 32,
+        height: 32,
+        decoration: const BoxDecoration(
+          color: Color(0xFFE0DFD3),
+          shape: BoxShape.circle,
+        ),
+        alignment: Alignment.center,
+        child: const Text(
+          '?',
+          style: TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.w700,
+            color: Color(0xFF555555),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _showStickerGuide() {
+    showDialog<void>(
+      context: context,
+      builder: (BuildContext ctx) {
+        return AlertDialog(
+          backgroundColor: const Color(0xFFEDE3FF),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+          contentPadding: const EdgeInsets.fromLTRB(24, 24, 24, 16),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: const <Widget>[
+              _GuideRow(color: null, label: '없음', description: '달성률 0%'),
+              SizedBox(height: 10),
+              _GuideRow(
+                color: Color(0xFFE32910),
+                label: null,
+                description: '달성률 0% 초과 ~ 30% 미만',
+              ),
+              SizedBox(height: 10),
+              _GuideRow(
+                color: Color(0xFFFFC943),
+                label: null,
+                description: '달성률 30% 이상 ~ 60% 미만',
+              ),
+              SizedBox(height: 10),
+              _GuideRow(
+                color: Color(0xFF13D62D),
+                label: null,
+                description: '달성률 60% 이상 ~ 100% 미만',
+              ),
+              SizedBox(height: 10),
+              _GuideRow(
+                color: Color(0xFF46C8FF),
+                label: null,
+                description: '달성률 100%',
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  // ────────────────────── BottomNavigationBar ──────────────────────
+  Widget _buildBottomNav() {
+    return BottomNavigationBar(
+      currentIndex: _currentTabIndex,
+      onTap: (int idx) => setState(() => _currentTabIndex = idx),
+      type: BottomNavigationBarType.fixed,
+      backgroundColor: Colors.white,
+      selectedItemColor: _primary,
+      unselectedItemColor: const Color(0xFF9E9E9E),
+      selectedLabelStyle: const TextStyle(fontWeight: FontWeight.w600),
+      items: const <BottomNavigationBarItem>[
+        BottomNavigationBarItem(
+          icon: Icon(Icons.calendar_today_outlined),
+          activeIcon: Icon(Icons.calendar_today),
+          label: 'Calendar',
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(Icons.check_box_outlined),
+          activeIcon: Icon(Icons.check_box),
+          label: 'To Do',
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(Icons.person_outline),
+          activeIcon: Icon(Icons.person),
+          label: 'My',
+        ),
+      ],
+    );
+  }
+}
+
+/// 안내 팝업 행: 스티커(또는 "없음" 라벨) + 설명 텍스트.
+class _GuideRow extends StatelessWidget {
+  const _GuideRow({
+    required this.color,
+    required this.label,
+    required this.description,
+  });
+
+  final Color? color;
+  final String? label;
+  final String description;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: <Widget>[
+        SizedBox(
+          width: 36,
+          child: color != null
+              ? Container(
+                  width: 14,
+                  height: 14,
+                  decoration: BoxDecoration(
+                    color: color,
+                    shape: BoxShape.circle,
+                  ),
+                )
+              : Text(
+                  label ?? '',
+                  style: const TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    color: Color(0xFF333333),
+                  ),
+                ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            description,
+            style: const TextStyle(
+              fontSize: 14,
+              color: Color(0xFF333333),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/calendar/view/calendar_screen.dart
+++ b/lib/features/calendar/view/calendar_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../shared/widgets/calendar_grid.dart';
+import '../../todo/view/todo_screen.dart';
 
 /// 캘린더 화면.
 ///
@@ -66,7 +67,26 @@ class _CalendarScreenState extends State<CalendarScreen> {
   final Map<int, double> _achievementRates = <int, double>{};
 
   /// 현재 선택된 BottomNavigation 인덱스 (0: Calendar, 1: To Do, 2: My)
-  int _currentTabIndex = 0;
+  static const int _tabIndex = 0;
+
+  /// BottomNavigationBar 탭 핸들러.
+  ///
+  /// 스펙(`.claude/agents/ui-implementor.md` `공유 위젯: BottomNavigationBar` 절):
+  /// - 동일 탭 재선택은 no-op.
+  /// - 다른 탭은 백 스택을 쌓지 않도록 `pushReplacement`로 화면 전환.
+  /// - go_router 도입 후 `context.go(...)`로 교체 예정.
+  void _onTabTapped(int index) {
+    if (index == _tabIndex) return;
+    switch (index) {
+      case 1:
+        Navigator.of(context).pushReplacement(
+          MaterialPageRoute<void>(builder: (_) => const TodoScreen()),
+        );
+      case 2:
+        // TODO(my-page): MyScreen 구현 후 pushReplacement 연결.
+        break;
+    }
+  }
 
   bool get _canGoPrev => _displayMonth.isAfter(_minMonth);
 
@@ -89,8 +109,11 @@ class _CalendarScreenState extends State<CalendarScreen> {
     int yellow = 0;
     int green = 0;
     int blue = 0;
-    final int daysInMonth =
-        DateTime(_displayMonth.year, _displayMonth.month + 1, 0).day;
+    final int daysInMonth = DateTime(
+      _displayMonth.year,
+      _displayMonth.month + 1,
+      0,
+    ).day;
     for (int day = 1; day <= daysInMonth; day++) {
       final double rate = _achievementRates[day] ?? 0;
       if (rate <= 0) continue;
@@ -124,7 +147,7 @@ class _CalendarScreenState extends State<CalendarScreen> {
                   _buildLegendBar(),
                   const SizedBox(height: 20),
                   _buildWeekdayHeader(),
-                  const SizedBox(height: 4),
+                  const SizedBox(height: 5),
                   Expanded(
                     child: CalendarGrid(
                       displayMonth: _displayMonth,
@@ -135,11 +158,7 @@ class _CalendarScreenState extends State<CalendarScreen> {
                 ],
               ),
             ),
-            Positioned(
-              top: 12,
-              right: 16,
-              child: _buildHelpButton(),
-            ),
+            Positioned(top: 12, right: 16, child: _buildHelpButton()),
           ],
         ),
       ),
@@ -247,7 +266,7 @@ class _CalendarScreenState extends State<CalendarScreen> {
                 textAlign: TextAlign.center,
                 style: const TextStyle(
                   fontSize: 12,
-                  fontWeight: FontWeight.w600,
+                  fontWeight: FontWeight.bold,
                   color: _primary,
                 ),
               ),
@@ -330,8 +349,8 @@ class _CalendarScreenState extends State<CalendarScreen> {
   // ────────────────────── BottomNavigationBar ──────────────────────
   Widget _buildBottomNav() {
     return BottomNavigationBar(
-      currentIndex: _currentTabIndex,
-      onTap: (int idx) => setState(() => _currentTabIndex = idx),
+      currentIndex: _tabIndex,
+      onTap: _onTabTapped,
       type: BottomNavigationBarType.fixed,
       backgroundColor: Colors.white,
       selectedItemColor: _primary,
@@ -398,10 +417,7 @@ class _GuideRow extends StatelessWidget {
         Expanded(
           child: Text(
             description,
-            style: const TextStyle(
-              fontSize: 14,
-              color: Color(0xFF333333),
-            ),
+            style: const TextStyle(fontSize: 14, color: Color(0xFF333333)),
           ),
         ),
       ],

--- a/lib/features/todo/view/todo_screen.dart
+++ b/lib/features/todo/view/todo_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../../shared/widgets/segmented_progress_bar.dart';
 import '../../../shared/widgets/todo_item_widget.dart';
+import '../../calendar/view/calendar_screen.dart';
 
 /// Todo 화면 (메인).
 ///
@@ -36,7 +37,26 @@ class _TodoScreenState extends State<TodoScreen> {
   );
 
   /// 현재 선택된 BottomNavigation 인덱스 (0: Calendar, 1: To Do, 2: My)
-  int _currentTabIndex = 1;
+  static const int _tabIndex = 1;
+
+  /// BottomNavigationBar 탭 핸들러.
+  ///
+  /// 스펙(`.claude/agents/ui-implementor.md` `공유 위젯: BottomNavigationBar` 절):
+  /// - 동일 탭 재선택은 no-op.
+  /// - 다른 탭은 백 스택을 쌓지 않도록 `pushReplacement`로 화면 전환.
+  /// - go_router 도입 후 `context.go(...)`로 교체 예정.
+  void _onTabTapped(int index) {
+    if (index == _tabIndex) return;
+    switch (index) {
+      case 0:
+        Navigator.of(context).pushReplacement(
+          MaterialPageRoute<void>(builder: (_) => const CalendarScreen()),
+        );
+      case 2:
+        // TODO(my-page): MyScreen 구현 후 pushReplacement 연결.
+        break;
+    }
+  }
 
   bool get _isToday {
     final DateTime now = DateTime.now();
@@ -165,8 +185,8 @@ class _TodoScreenState extends State<TodoScreen> {
 
   Widget _buildBottomNav() {
     return BottomNavigationBar(
-      currentIndex: _currentTabIndex,
-      onTap: (int idx) => setState(() => _currentTabIndex = idx),
+      currentIndex: _tabIndex,
+      onTap: _onTabTapped,
       type: BottomNavigationBarType.fixed,
       backgroundColor: Colors.white,
       selectedItemColor: const Color(0xFF512DA8),

--- a/lib/shared/widgets/achievement_sticker.dart
+++ b/lib/shared/widgets/achievement_sticker.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+/// 달성률을 색상이 있는 원형 도트로 시각화하는 스티커.
+///
+/// 색상 규칙(`.claude/rules/project-overview.md`):
+/// | 달성률 | 색상 |
+/// |--------|------|
+/// | 0%                  | 표기 안 함 (스티커 없음) |
+/// | 0% 초과 ~ 30% 미만  | `#e32910` (빨강)         |
+/// | 30% 이상 ~ 60% 미만 | `#FFC943` (노랑)         |
+/// | 60% 이상 ~ 100% 미만| `#13d62d` (초록)         |
+/// | 100%                | `#46C8FF` (파랑)         |
+///
+/// 달성률이 0인 경우 [SizedBox.shrink]를 반환한다.
+class AchievementSticker extends StatelessWidget {
+  const AchievementSticker({
+    super.key,
+    required this.rate,
+    this.size = 10,
+  });
+
+  /// 달성률 (0.0 ~ 1.0).
+  final double rate;
+
+  /// 도트 지름.
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final Color? color = resolveColor(rate);
+    if (color == null) {
+      return const SizedBox.shrink();
+    }
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: color,
+        shape: BoxShape.circle,
+      ),
+    );
+  }
+
+  /// 달성률에 대응하는 스티커 색상. 0%인 경우 `null`을 반환한다.
+  static Color? resolveColor(double rate) {
+    if (rate <= 0) return null;
+    if (rate < 0.30) return const Color(0xFFE32910);
+    if (rate < 0.60) return const Color(0xFFFFC943);
+    if (rate < 1.00) return const Color(0xFF13D62D);
+    return const Color(0xFF46C8FF);
+  }
+}

--- a/lib/shared/widgets/calendar_grid.dart
+++ b/lib/shared/widgets/calendar_grid.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+
+import 'achievement_sticker.dart';
+
+/// 7열 × 최대 6행 형태의 월별 날짜 그리드.
+///
+/// - [displayMonth]가 가리키는 달의 1일이 위치하는 요일에 맞춰 빈 셀을 채워 넣는다.
+/// - 각 날짜 셀은 다음 레이어로 구성된다:
+///   ```
+///   Stack
+///    ├─ Container(circle, #512DA8)  ← 오늘 날짜만
+///    ├─ Text(날짜 숫자)
+///    └─ Positioned(bottom) AchievementSticker  ← 달성률 > 0인 날만
+///   ```
+/// - 날짜 탭 인터랙션은 v1.0.0 스펙상 없음.
+class CalendarGrid extends StatelessWidget {
+  const CalendarGrid({
+    super.key,
+    required this.displayMonth,
+    required this.today,
+    required this.achievementRates,
+  });
+
+  /// 표시할 달 (해당 월의 임의의 날짜를 받아 year/month만 사용).
+  final DateTime displayMonth;
+
+  /// 오늘 날짜 (현재 날짜 강조용).
+  final DateTime today;
+
+  /// 일자(`day`)별 달성률 (0.0 ~ 1.0).
+  final Map<int, double> achievementRates;
+
+  static const Color _primary = Color(0xFF512DA8);
+
+  @override
+  Widget build(BuildContext context) {
+    final int year = displayMonth.year;
+    final int month = displayMonth.month;
+
+    // 해당 월의 1일이 어느 요일에 위치하는지 (DateTime.weekday: 월=1 ~ 일=7).
+    // 캘린더는 SUN ~ SAT 순이므로 일요일을 0으로 환산.
+    final int firstWeekday = DateTime(year, month, 1).weekday % 7;
+    final int daysInMonth = DateTime(year, month + 1, 0).day;
+    final int totalCells = firstWeekday + daysInMonth;
+    // 7의 배수로 올림 (마지막 행이 비어도 동일한 셀 크기를 유지하기 위해).
+    final int rowCount = (totalCells / 7).ceil();
+    final int gridCount = rowCount * 7;
+
+    return GridView.builder(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      padding: EdgeInsets.zero,
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 7,
+        childAspectRatio: 1,
+      ),
+      itemCount: gridCount,
+      itemBuilder: (BuildContext context, int index) {
+        final int day = index - firstWeekday + 1;
+        if (day < 1 || day > daysInMonth) {
+          return _emptyCell();
+        }
+        final bool isToday = year == today.year &&
+            month == today.month &&
+            day == today.day;
+        final double rate = achievementRates[day] ?? 0;
+        return _dayCell(day: day, isToday: isToday, rate: rate);
+      },
+    );
+  }
+
+  Widget _emptyCell() {
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(color: const Color(0xFFD8D5C8), width: 0.5),
+      ),
+    );
+  }
+
+  Widget _dayCell({
+    required int day,
+    required bool isToday,
+    required double rate,
+  }) {
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(color: const Color(0xFFD8D5C8), width: 0.5),
+      ),
+      child: Stack(
+        alignment: Alignment.center,
+        children: <Widget>[
+          if (isToday)
+            Container(
+              width: 28,
+              height: 28,
+              decoration: const BoxDecoration(
+                color: _primary,
+                shape: BoxShape.circle,
+              ),
+            ),
+          Text(
+            '$day',
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w500,
+              color: isToday ? Colors.white : const Color(0xFF333333),
+            ),
+          ),
+          Positioned(
+            bottom: 6,
+            child: AchievementSticker(rate: rate, size: 8),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/shared/widgets/calendar_grid.dart
+++ b/lib/shared/widgets/calendar_grid.dart
@@ -46,25 +46,31 @@ class CalendarGrid extends StatelessWidget {
     final int rowCount = (totalCells / 7).ceil();
     final int gridCount = rowCount * 7;
 
-    return GridView.builder(
-      shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(),
-      padding: EdgeInsets.zero,
-      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-        crossAxisCount: 7,
-        childAspectRatio: 1,
-      ),
-      itemCount: gridCount,
-      itemBuilder: (BuildContext context, int index) {
-        final int day = index - firstWeekday + 1;
-        if (day < 1 || day > daysInMonth) {
-          return _emptyCell();
-        }
-        final bool isToday = year == today.year &&
-            month == today.month &&
-            day == today.day;
-        final double rate = achievementRates[day] ?? 0;
-        return _dayCell(day: day, isToday: isToday, rate: rate);
+    // 가용 높이를 행 수로 나눠 셀 높이를 결정 → 그리드가 항상 부모 영역을 꽉 채운다.
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final double cellHeight = constraints.maxHeight / rowCount;
+        return GridView.builder(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          padding: EdgeInsets.zero,
+          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: 7,
+            mainAxisExtent: cellHeight,
+          ),
+          itemCount: gridCount,
+          itemBuilder: (BuildContext context, int index) {
+            final int day = index - firstWeekday + 1;
+            if (day < 1 || day > daysInMonth) {
+              return _emptyCell();
+            }
+            final bool isToday = year == today.year &&
+                month == today.month &&
+                day == today.day;
+            final double rate = achievementRates[day] ?? 0;
+            return _dayCell(day: day, isToday: isToday, rate: rate);
+          },
+        );
       },
     );
   }
@@ -82,33 +88,46 @@ class CalendarGrid extends StatelessWidget {
     required bool isToday,
     required double rate,
   }) {
+    // 날짜 숫자: 세로 상단 + 가로 중앙 정렬.
+    // 오늘 강조 원은 숫자를 감싸는 형태로 상단에 함께 배치.
+    // 스티커는 셀 하단 중앙.
     return Container(
       decoration: BoxDecoration(
         border: Border.all(color: const Color(0xFFD8D5C8), width: 0.5),
       ),
       child: Stack(
-        alignment: Alignment.center,
         children: <Widget>[
-          if (isToday)
-            Container(
-              width: 28,
-              height: 28,
-              decoration: const BoxDecoration(
-                color: _primary,
-                shape: BoxShape.circle,
+          Align(
+            alignment: Alignment.topCenter,
+            child: Padding(
+              padding: const EdgeInsets.only(top: 6),
+              child: Container(
+                width: 24,
+                height: 24,
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: isToday ? _primary : Colors.transparent,
+                  shape: BoxShape.circle,
+                ),
+                child: Text(
+                  '$day',
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.bold,
+                    color: isToday
+                        ? Colors.white
+                        : const Color(0xFF333333),
+                  ),
+                ),
               ),
             ),
-          Text(
-            '$day',
-            style: TextStyle(
-              fontSize: 14,
-              fontWeight: FontWeight.w500,
-              color: isToday ? Colors.white : const Color(0xFF333333),
-            ),
           ),
-          Positioned(
-            bottom: 6,
-            child: AchievementSticker(rate: rate, size: 8),
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: 6),
+              child: AchievementSticker(rate: rate, size: 8),
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
## 개요

하루 3개 목표 달성률을 한눈에 확인할 수 있는 캘린더 화면을 새로 구현하고, Calendar ↔ Todo 화면 사이를 BottomNavigationBar로 이동할 수 있도록 네비게이션 규칙을 통일했다. ViewModel/Repository 연동 전 단계의 **MVP UI**이며, 달성률 데이터는 빈 Map으로 초기화한다.

## 주요 변경사항

### 캘린더 화면 신규 구현

- `lib/features/calendar/view/calendar_screen.dart` 추가 — 월 네비게이션 헤더, 요일 헤더(SUN~SAT), 달성률 범례 바, 우상단 `?` 버튼(스티커 안내 팝업), `Expanded`로 채우는 그리드 영역으로 구성.
- 월 이동 규칙: 최소 월은 **2026년 4월**(스펙상 시작일)로 좌측 화살표 비활성, 우측은 항상 활성.
- 색상/폰트는 디자인 시스템(`#512DA8`, `#F3F4EB`)을 그대로 적용.

### 공통 위젯 분리

- `lib/shared/widgets/calendar_grid.dart` — 7열 × 가변 행(`(firstWeekday + daysInMonth) / 7`) 그리드. `LayoutBuilder`로 부모 높이를 행 수로 나눠 셀 크기를 결정해 그리드가 항상 화면을 꽉 채운다. 오늘 날짜는 보라색 원형으로 강조하고, 달성률이 0보다 큰 날에만 스티커를 표시.
- `lib/shared/widgets/achievement_sticker.dart` — 달성률 구간별 색상 매핑(`#e32910` / `#FFC943` / `#13d62d` / `#46C8FF`). 0%인 날은 `SizedBox.shrink()`로 그리지 않아 스펙(`.claude/rules/project-overview.md`)과 일치시킴.

### BottomNav 네비게이션 규칙 통일

- Calendar/Todo 화면 양쪽에 `_tabIndex` 상수와 `_onTabTapped` 핸들러를 도입해 동일 탭 재선택은 no-op, 다른 탭은 `Navigator.pushReplacement`로 전환하도록 통일.
- 백 스택을 쌓지 않는 이유: BottomNav 탭 간 이동은 형제 화면이며, 누적되면 뒤로가기 동작이 사용자 기대와 어긋난다. go_router 도입 후 `context.go(...)`로 교체할 수 있도록 TODO 주석으로 표시.
- My 탭은 아직 미구현이라 `// TODO(my-page)` 주석으로 자리만 두고 실제 네비게이션은 비워뒀다.

### 스펙 문서 갱신

- `.claude/agents/ui-implementor.md`에 BottomNavigationBar 탭 인덱스(0/1/2) 및 화면 매핑 표, 네비게이션 동작 규칙(no-op / replace / TODO 처리)을 명시.
- `.claude/agents/ui-implementor/02_todo.md`, `03_calendar.md`, `04_mypage.md`와 `.claude/ui/v1.0.0/` 화면 명세에 같은 매핑을 반영해 후속 작업이 동일한 규칙을 따르도록 함.

## 스크린샷 / 데모

해당 없음 (UI 캡처는 후속 PR에서 ViewModel 연결 후 첨부 예정).

## 테스트 방법

- [x] `flutter pub get` 후 `flutter run`
- [x] Todo 화면에서 BottomNav `Calendar` 탭을 눌러 캘린더로 이동, 다시 `To Do`로 복귀해도 백 스택이 쌓이지 않는지 확인
- [x] 캘린더 화면에서 좌/우 화살표로 월 이동 시 2026년 4월 이전으로는 갈 수 없는지 확인
- [x] 오늘 날짜가 보라색 원으로 강조되고, 비어 있는 셀(달의 시작 전)이 정상적으로 빈 칸으로 표시되는지 확인
- [x] 우상단 `?` 버튼을 눌러 스티커 색상 안내 팝업이 뜨는지 확인

## 관련 문서 / 이슈

- `.claude/ui/v1.0.0/03_캘린더화면.md`
- `.claude/agents/ui-implementor/03_calendar.md`
- `.claude/rules/project-overview.md` (달성률 색상 규칙)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)