### PR TITLE
ci: 릴리즈 태그·GitHub Release 자동화 워크플로 도입

### DIFF
--- a/.claude/commands/hotfix.md
+++ b/.claude/commands/hotfix.md
@@ -7,8 +7,10 @@
 1. **`main` 에서 분기**한다. `develop` 에서 분기 금지 (develop 의 미출시 기능이 섞이면 안 됨).
 2. **`main` 머지는 PR 경유 (`gh pr merge`)**. 직접 push 금지.
 3. **반드시 `develop` 에도 back-merge** 한다. 생략 시 다음 릴리즈에서 같은 버그 재발.
-4. **패치 태그(`vX.Y.(Z+1)`) + GitHub Release** 는 필수. 릴리즈 노트는 간단해도 반드시 작성.
-5. **force push / 태그 삭제 / 릴리즈 삭제 금지.** 이전 릴리즈 `vX.Y.Z` 의 태그와 릴리즈 노트는 그대로 보존한다 ("어떤 일이 있었고, 어떻게 고쳤는지" 추적 가능하게).
+4. **패치 태그(`vX.Y.(Z+1)`) + GitHub Release** 는 GitHub Actions `release-publish` 워크플로가 자동 생성한다. 로컬/수동 `git tag` · `gh release create` 금지. 실패 시 `workflow_dispatch` 로 재실행.
+5. **PR 제목은 반드시 `hotfix: vX.Y.(Z+1) ...` 형식.** 워크플로가 제목 prefix 로 hotfix PR 을 식별한다.
+6. **PR 본문에 릴리즈 노트를 반드시 작성.** 워크플로가 PR 본문을 그대로 Release 본문으로 사용한다 (비어 있으면 게이트 실패).
+7. **force push / 태그 삭제 / 릴리즈 삭제 금지.** 이전 릴리즈 `vX.Y.Z` 의 태그와 릴리즈 노트는 그대로 보존한다 ("어떤 일이 있었고, 어떻게 고쳤는지" 추적 가능하게).
 
 ## 사전 조건
 
@@ -101,28 +103,33 @@ gh pr merge "$PR_NUMBER" --merge --delete-branch=false
 - `--delete-branch=false` 로 브랜치 유지 (§7 back-merge 후 일괄 정리).
 - 충돌 발생 시 중단하고 사용자에게 알린다. 자동 resolve 금지.
 
-### 6. 패치 태그 + GitHub Release
+### 6. GitHub Actions `release-publish` 워크플로 완료 확인
+
+§5 PR 머지 직후 `.github/workflows/release-publish.yml` 이 자동 실행된다. PR 제목 prefix 가 `hotfix:` 이므로 워크플로 필터를 통과하고, 워크플로가 `vX.Y.(Z+1)` annotated 태그 + GitHub Release 를 자동 생성한다.
+
+**로컬에서 `git tag` / `gh release create` 를 직접 호출하지 않는다.**
 
 ```bash
-git checkout main
-git pull origin main
+# 실행 결과 확인
+gh run list --workflow=release-publish.yml --limit 3
+gh run watch  # 진행 중이면
 
-# annotated 태그
-git tag -a vX.Y.(Z+1) -m "hotfix: <버그 요약>"
-git push origin vX.Y.(Z+1)
-
-# GitHub Release 공개 (릴리즈 노트 필수)
-gh release create vX.Y.(Z+1) \
-  --target main \
-  --title "vX.Y.(Z+1) — Hotfix" \
-  --notes "$(cat <<'EOF'
-<§4 의 hotfix 릴리즈 노트 본문>
-EOF
-)"
+# 태그 / Release 검증
+git fetch --tags origin
+git tag -l vX.Y.*
+gh release view vX.Y.(Z+1) --json url,name
 ```
 
-- 태그는 반드시 main 의 머지 커밋 SHA 에 찍는다.
-- 릴리즈 노트를 생략하고 태그만 push 하는 것은 금지.
+#### 워크플로 실패 복구
+
+```bash
+gh workflow run release-publish.yml \
+  -f version=vX.Y.(Z+1) \
+  -f sha=<머지 커밋 SHA> \
+  -f pr_number=<hotfix PR 번호>
+```
+
+자세한 원인별 대응은 `.claude/commands/release.md` §8 "워크플로 실패 복구" 참조 (hotfix 도 동일 워크플로 사용).
 
 ### 7. `develop` back-merge (필수)
 
@@ -165,6 +172,6 @@ git push origin --delete hotfix/vX.Y.(Z+1)
 ## 실패 / 복구
 
 - **§5 PR 머지 충돌**: hotfix 브랜치에서 `git merge origin/main` 으로 충돌 해결 → 재시도.
-- **§6 태그 생성 실패**: 이미 `vX.Y.(Z+1)` 태그가 존재한다면 이전 hotfix 시도가 중단된 상태일 수 있음. 태그가 가리키는 커밋이 현재 main HEAD 와 일치하는지 확인 후 진행.
+- **§6 워크플로 실행 안 됨 / 실패**: PR 제목 prefix 가 `hotfix:` 아니거나, PR 본문이 비어 있으면 트리거/게이트에서 실패한다. 제목·본문 정정 후 `gh workflow run release-publish.yml -f version=... -f sha=... -f pr_number=...` 로 수동 재실행. 로컬에서 태그 직접 생성 금지.
 - **§7 back-merge 충돌**: develop 의 변경과 충돌 → develop 에서 수동 해결 후 머지. 이 경우에도 force push 금지.
 - **hotfix 자체가 또 다른 버그를 유발**: 또 다른 hotfix (`vX.Y.(Z+2)`) 를 만든다. 이전 hotfix 태그/릴리즈는 그대로 둔다.

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,14 +1,16 @@
-`develop` 브랜치에 누적된 변경사항을 분석해 다음 릴리즈 버전(`vX.Y.Z`)을 결정하고, git-flow 규칙에 따라 **release 브랜치 생성 → release PR → `main` PR 머지 → `vX.Y.Z` 태그 → GitHub Release 공개 → `develop` back-merge** 까지 처리한다.
+`develop` 브랜치에 누적된 변경사항을 분석해 다음 릴리즈 버전(`vX.Y.Z`)을 결정하고, git-flow 규칙에 따라 **release 브랜치 생성 → release PR → `main` PR 머지 → (GitHub Actions 가 `vX.Y.Z` 태그 + GitHub Release 자동 생성) → `develop` back-merge** 까지 처리한다.
 
-전체 규칙은 `.claude/rules/git-flow.md` 참조. 잘못된 릴리즈 복구는 **`/hotfix` 커맨드만 사용**한다 (revert 금지, 태그/릴리즈 삭제 금지).
+전체 규칙은 `.claude/rules/git-flow.md`, 자동화 설계는 `.claude/plans/deployment-plan.md` § "CI 자동화" 참조. 잘못된 릴리즈 복구는 **`/hotfix` 커맨드만 사용**한다 (revert 금지, 태그/릴리즈 삭제 금지).
 
 ## 절대 규칙 (이 커맨드가 지켜야 하는 것)
 
 1. **`main` 직접 push 금지.** 모든 main 반영은 `gh pr merge` 를 통해 진행한다. 서버 측 branch protection + 로컬 pre-push hook 이 이중으로 차단한다.
-2. **릴리즈 노트 없이 머지 금지.** §6 에서 릴리즈 노트 초안이 확정되기 전에는 `gh pr merge` 로 넘어가지 않는다. 릴리즈 노트는 release PR 본문 + GitHub Release 양쪽에 모두 게시한다.
+2. **릴리즈 노트 없이 머지 금지.** §6 에서 릴리즈 노트 초안이 확정되기 전에는 `gh pr merge` 로 넘어가지 않는다. 릴리즈 노트는 **PR 본문에 게시**하며, GitHub Release 본문은 워크플로가 PR 본문을 그대로 재사용한다.
 3. **force push / 태그 삭제 / 릴리즈 삭제 전면 금지.** 이미 찍힌 태그와 릴리즈 노트는 기록으로 보존한다.
 4. **back-merge 생략 금지.** release 브랜치는 main 머지 후 반드시 develop 에도 머지한다.
 5. **버전 판정은 반드시 사용자 확인.** 자동 판정 결과만 믿고 진행하지 않는다.
+6. **태그·Release 는 워크플로 자동 생성에 위임.** 로컬/수동으로 `git tag` / `gh release create` 실행 금지. 실패 시 `workflow_dispatch` 로 재실행한다 (§8 복구 절차).
+7. **PR 제목 형식은 `release: vX.Y.Z`.** 워크플로가 제목 prefix 로 릴리즈 PR 을 식별한다. 다른 형식이면 자동화가 발화되지 않는다.
 
 ## 사전 조건
 
@@ -157,32 +159,56 @@ gh pr merge "$PR_NUMBER" --merge --delete-branch=false
 - `--delete-branch=false` 로 release 브랜치를 남겨둔다 (§9 back-merge 이후 일괄 정리).
 - 머지가 실패하면 (충돌 등) 중단하고 사용자에게 알린다. 자동 resolve 금지.
 
-### 8. main 최신 커밋에 태그 생성 + GitHub Release 공개
+### 8. GitHub Actions `release-publish` 워크플로 완료 확인
+
+§7 PR 머지 직후 `pull_request_target: closed` 이벤트로 `.github/workflows/release-publish.yml` 이 자동 실행된다. **로컬에서 `git tag` / `gh release create` 를 직접 호출하지 않는다.**
+
+워크플로가 수행하는 작업:
+1. PR 제목에서 `vX.Y.Z` 추출 + 형식 검증
+2. 머지 커밋 SHA 가 `origin/main` 의 조상인지 검증
+3. PR 본문을 릴리즈 노트로 사용 (비어 있으면 실패)
+4. annotated 태그 `vX.Y.Z` 생성 + push
+5. `gh release create` 로 GitHub Release 공개 (idempotent)
+
+#### 확인
 
 ```bash
-# 1) main 최신화
-git checkout main
-git pull origin main
+# 최근 실행 결과 조회
+gh run list --workflow=release-publish.yml --limit 3
 
-# 2) annotated 태그 생성
-git tag -a vX.Y.Z -m "릴리즈 vX.Y.Z"
+# 진행 중이면 최신 실행을 watch
+gh run watch
 
-# 3) 태그 push
-git push origin vX.Y.Z
-
-# 4) GitHub Release 생성 (릴리즈 노트 필수 포함)
-gh release create vX.Y.Z \
-  --target main \
-  --title "vX.Y.Z" \
-  --notes "$(cat <<'EOF'
-<§6 의 릴리즈 노트 본문 그대로>
-EOF
-)"
+# 태그 / Release 공개 검증
+git fetch --tags origin
+git tag -l vX.Y.Z
+gh release view vX.Y.Z --json url,name,publishedAt
 ```
 
-- 태그는 **반드시 main 의 머지 커밋에** 찍는다 (`git checkout main && git pull` 로 최신화 후).
-- annotated 태그(`-a`) 만 사용한다 (lightweight 금지).
-- `gh release create` 를 생략하면 릴리즈 노트가 공개되지 않는다 → **반드시 생성**.
+- 워크플로 상태가 `completed / success` 여야 §9 back-merge 로 진행한다.
+- 태그가 이미 존재하면 워크플로는 태그 생성을 스킵하고 Release 본문만 갱신한다 (재실행 안전).
+
+#### 워크플로 실패 복구
+
+실패 원인별 대응:
+
+| 증상 | 원인 | 복구 |
+|------|------|------|
+| 워크플로가 아예 실행 안 됨 | PR 제목이 `release:` prefix 아님 / head 가 `release/*` 아님 | 제목/브랜치 수정 후 `workflow_dispatch` 수동 실행 |
+| 버전 추출 실패 | PR 제목에 `vX.Y.Z` 없음 | 제목 정정 후 `workflow_dispatch` 재실행 |
+| PR 본문 비어 있음 → 릴리즈 노트 게이트 실패 | §6 누락 | PR 본문에 릴리즈 노트 추가 → `workflow_dispatch` 재실행 |
+| 네트워크 / API 일시 실패 | GitHub Actions 측 이슈 | 동일 입력으로 `workflow_dispatch` 재실행 |
+
+수동 재실행:
+
+```bash
+gh workflow run release-publish.yml \
+  -f version=vX.Y.Z \
+  -f sha=<머지 커밋 SHA> \
+  -f pr_number=<릴리즈 PR 번호>
+```
+
+> ⚠️ 워크플로 실패를 우회해 로컬에서 `git tag -a && git push origin vX.Y.Z` 를 직접 실행하는 것은 **금지**. 반드시 `workflow_dispatch` 로 재시도한다.
 
 ### 9. `develop` 으로 back-merge
 

--- a/.claude/plans/deployment-plan.md
+++ b/.claude/plans/deployment-plan.md
@@ -83,15 +83,15 @@ main 배포를 진행하기 전 아래 항목을 모두 확인한다.
 6. 릴리즈 노트 작성 (필수 게이트 — 확정 전 §7 진행 불가)
 7. gh pr create --base main --head release/vX.Y.Z
 8. gh pr merge <PR_NUMBER> --merge --delete-branch=false
-9. git checkout main && git pull
-10. git tag -a vX.Y.Z -m "릴리즈 vX.Y.Z" && git push origin vX.Y.Z
-11. gh release create vX.Y.Z --target main --notes "<릴리즈 노트>"
-12. develop 으로 back-merge (버전 bump 동기화)
-13. release/vX.Y.Z 브랜치 삭제
+   ↓ (이 시점 GitHub Actions `release-publish` 가 자동 트리거)
+9. 워크플로 완료 확인 — 태그 vX.Y.Z + GitHub Release 자동 생성 검증
+10. git checkout develop && git pull && git merge --no-ff release/vX.Y.Z
+11. release/vX.Y.Z 브랜치 삭제
 ```
 
 상세 절차: `.claude/commands/release.md`
 트리거: `/release` 슬래시 커맨드
+자동화: `.github/workflows/release-publish.yml` (§ "CI 자동화" 참조)
 
 ---
 
@@ -105,14 +105,66 @@ main 배포를 진행하기 전 아래 항목을 모두 확인한다.
 3. 버그 수정 커밋 (fix: 또는 revert: 접두어)
 4. gh pr create --base main --head hotfix/vX.Y.(Z+1)
 5. gh pr merge --merge
-6. git tag -a vX.Y.(Z+1) && git push origin vX.Y.(Z+1)
-7. gh release create vX.Y.(Z+1) --notes "<hotfix 릴리즈 노트>"
-8. develop 으로 back-merge (동일 버그 재발 방지)
-9. hotfix 브랜치 삭제
+   ↓ (이 시점 GitHub Actions `release-publish` 가 자동 트리거)
+6. 워크플로 완료 확인 — 패치 태그 vX.Y.(Z+1) + GitHub Release 자동 생성 검증
+7. develop 으로 back-merge (동일 버그 재발 방지)
+8. hotfix 브랜치 삭제
 ```
 
 상세 절차: `.claude/commands/hotfix.md`
 트리거: `/hotfix` 슬래시 커맨드
+자동화: `.github/workflows/release-publish.yml` (§ "CI 자동화" 참조)
+
+---
+
+## CI 자동화 (`.github/workflows/release-publish.yml`)
+
+태그 생성과 GitHub Release 공개를 수동 단계에서 분리해, PR 머지 이벤트에 맞춰 GitHub Actions 가 대신 수행한다. 사람/에이전트의 단계 누락(이번 v1.0.0 처럼 태그·Release 누락)을 구조적으로 막기 위함이다.
+
+### 트리거
+
+| 이벤트 | 실행 조건 |
+|--------|----------|
+| `pull_request_target` (closed, base=main) | `merged == true` **AND** PR 제목이 `release:` 또는 `hotfix:` 로 시작 |
+| `workflow_dispatch` | 수동 입력 (version / sha / pr_number) — 소급 태깅 · 실패 복구 용도 |
+
+> ⚠️ release/* 브랜치에서 올라온 **비릴리즈 PR** (예: `ci:`, `docs:` 로 시작)은 필터에 걸려 실행되지 않는다. "릴리즈 PR" 임을 제목 prefix 로 구분한다.
+
+### 작업 순서
+
+1. `main` 체크아웃 (`fetch-depth: 0`)
+2. 메타 추출
+   - PR 제목에서 `vX.Y.Z` 정규식 매칭 → `VERSION`
+   - 머지 커밋 SHA = `pull_request.merge_commit_sha`
+   - PR 번호 = `pull_request.number`
+3. 게이트
+   - 버전 형식 검증 (`^v[0-9]+\.[0-9]+\.[0-9]+$`)
+   - SHA 가 `origin/main` 의 조상인지 `git merge-base --is-ancestor` 로 검증
+   - PR 본문 비어 있으면 실패 (릴리즈 노트 필수)
+   - 동일 태그 이미 존재 → 태그 생성은 스킵, Release 본문만 갱신 (idempotent)
+4. annotated 태그 생성 + push (`git tag -a $VERSION $SHA`)
+5. `gh release create` (이미 있으면 `gh release edit` 로 본문 갱신)
+6. Summary 출력 (버전 / SHA / 트리거 / PR)
+
+### 안전 장치
+
+- `permissions: contents: write, pull-requests: read` — 최소 권한만 부여
+- 태그·Release 양쪽 idempotent → 재실행 가능
+- 실패 시 커맨드 fallback: `.claude/commands/release.md` §8 "워크플로 실패 복구" 절 참조
+- **태그 삭제 / Release 삭제는 절대 금지** (워크플로도 이 동작은 수행하지 않음)
+
+### 소급 적용 · 재실행 방법
+
+이미 머지됐지만 태그·Release 가 없는 릴리즈(예: v1.0.0) 또는 워크플로 실패 시:
+
+```bash
+gh workflow run release-publish.yml \
+  -f version=v1.0.0 \
+  -f sha=<머지 커밋 SHA> \
+  -f pr_number=<릴리즈 PR 번호>
+```
+
+실행 결과는 `gh run list --workflow=release-publish.yml --limit 1` 로 확인.
 
 ---
 
@@ -195,8 +247,8 @@ v1.1.0 배포 후 문제 발견 → hotfix/v1.1.1 분기 → git revert <bad-com
 4. **릴리즈 노트 초안 확정 전 main 머지 금지** — 사용자 승인 후 `gh pr merge`.
 5. **`git push origin main` 직접 호출 금지** — 항상 `gh pr merge` 경유.
 6. **back-merge 생략 금지** — release 브랜치를 develop 에도 반드시 반영.
-7. **annotated 태그만 사용** — `git tag -a vX.Y.Z`. lightweight 태그 금지.
-8. **`gh release create` 반드시 실행** — 태그만 push 하고 GitHub Release 생략 금지.
+7. **태그·GitHub Release 는 워크플로가 자동 생성** — 머지 이후 `gh run list --workflow=release-publish.yml` 로 성공 확인. 실패 시 `workflow_dispatch` 로 재실행 (태그/Release 직접 생성 금지).
+8. **PR 제목은 반드시 `release: vX.Y.Z` 형식** — 제목 prefix 로 워크플로가 릴리즈 PR 을 식별한다.
 
 ### `/hotfix` 실행 시
 
@@ -204,7 +256,8 @@ v1.1.0 배포 후 문제 발견 → hotfix/v1.1.1 분기 → git revert <bad-com
 2. **hotfix 브랜치 내 `git revert` 허용** — 원인 제거 커밋 또는 `git revert` 모두 가능.
 3. **main / develop 에서 직접 `git revert` 금지** — 반드시 hotfix 브랜치 경유.
 4. **develop back-merge 필수** — 핫픽스 내용이 다음 릴리즈에도 반영되어야 함.
-5. **릴리즈 노트 간단해도 반드시 작성** — `gh release create` 생략 금지.
+5. **릴리즈 노트 간단해도 반드시 PR 본문에 작성** — 워크플로가 PR 본문을 Release 노트로 사용한다. 본문이 비면 워크플로가 실패 처리.
+6. **PR 제목은 반드시 `hotfix: vX.Y.(Z+1) ...` 형식** — 워크플로 식별 조건.
 
 ### 공통
 

--- a/.claude/rules/git-flow.md
+++ b/.claude/rules/git-flow.md
@@ -119,13 +119,13 @@ Just Three 앱의 브랜치 전략은 [git-flow](https://danielkummer.github.io/
 3. `release/vX.Y.Z` 브랜치를 `develop` 에서 분기.
 4. 버전 bump / 메타 업데이트.
 5. **릴리즈 노트 작성** (아래 "릴리즈 노트 필수 규칙" 절 참조).
-6. `release/vX.Y.Z` → `main` 으로 **PR 생성 + `gh pr merge --merge`** (직접 merge/push 금지).
-7. 머지 완료 후 main 최신 커밋에 `vX.Y.Z` annotated 태그 생성 + push.
-8. `gh release create vX.Y.Z` 로 GitHub Release 생성 (릴리즈 노트 본문 반드시 포함).
+6. `release/vX.Y.Z` → `main` 으로 **PR 생성 + `gh pr merge --merge`** (직접 merge/push 금지). PR 제목은 `release: vX.Y.Z` 형식.
+7. **GitHub Actions `release-publish` 워크플로 자동 실행** — 머지 커밋에 `vX.Y.Z` annotated 태그 + GitHub Release 생성.
+8. 워크플로 완료 확인 (`gh run list --workflow=release-publish.yml --limit 1`) → 실패 시 `workflow_dispatch` 로 재실행.
 9. `release/vX.Y.Z` 를 `develop` 으로도 back-merge (버전 정보 동기화).
 10. `release/vX.Y.Z` 브랜치 삭제.
 
-상세 절차는 `.claude/commands/release.md` 참조.
+상세 절차는 `.claude/commands/release.md`, 워크플로 설계는 `.claude/plans/deployment-plan.md` § "CI 자동화" 참조.
 
 ### 릴리즈 노트 필수 규칙
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,182 @@
+name: release-publish
+
+# release/* · hotfix/* 브랜치가 main 에 머지되면 자동으로
+#   1) 머지 커밋에 annotated 태그 (vX.Y.Z) 생성 + push
+#   2) GitHub Release 공개 (본문 = PR body)
+# workflow_dispatch 로 수동 트리거도 지원한다 (소급 태깅 / 실패 재실행).
+#
+# 설계 규칙은 .claude/plans/deployment-plan.md 와
+# .claude/rules/git-flow.md 참조.
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '태그 버전 (vX.Y.Z)'
+        required: true
+        type: string
+      sha:
+        description: '태그를 찍을 커밋 SHA (main 에 포함되어야 함)'
+        required: true
+        type: string
+      pr_number:
+        description: '릴리즈 노트 본문을 가져올 PR 번호'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # 트리거 필터:
+    #   - workflow_dispatch: 항상 실행
+    #   - pull_request_target: merged == true 이고, PR 제목이
+    #     "release:" 또는 "hotfix:" 로 시작하는 경우에만 실행
+    #     (release/* 브랜치에서 오는 CI/docs 성격의 PR 은 제외)
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       (startsWith(github.event.pull_request.title, 'release:') ||
+        startsWith(github.event.pull_request.title, 'hotfix:')))
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Resolve version / sha / pr_number
+        id: meta
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_SHA: ${{ inputs.sha }}
+          INPUT_PR: ${{ inputs.pr_number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$INPUT_VERSION"
+            SHA="$INPUT_SHA"
+            PR_NUM="$INPUT_PR"
+          else
+            # "release: v1.2.3" / "hotfix: v1.2.3 버그 요약" 등에서 vX.Y.Z 추출
+            VERSION=$(printf '%s' "$PR_TITLE" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
+            SHA="$PR_MERGE_SHA"
+            PR_NUM="$PR_NUMBER"
+          fi
+
+          if [ -z "${VERSION:-}" ]; then
+            echo "::error::버전을 추출할 수 없음 (PR 제목 또는 input 확인)"
+            exit 1
+          fi
+
+          if ! printf '%s' "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::버전 형식 불일치: '$VERSION' (예상: vX.Y.Z)"
+            exit 1
+          fi
+
+          if [ -z "${SHA:-}" ]; then
+            echo "::error::태그를 찍을 SHA 가 비어 있음"
+            exit 1
+          fi
+
+          if [ -z "${PR_NUM:-}" ]; then
+            echo "::error::PR 번호가 비어 있음"
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$PR_NUM" >> "$GITHUB_OUTPUT"
+          echo "버전 = $VERSION / SHA = $SHA / PR = #$PR_NUM"
+
+      - name: Idempotency guard — 태그가 이미 존재하면 스킵
+        id: tag_guard
+        run: |
+          set -euo pipefail
+          VERSION='${{ steps.meta.outputs.version }}'
+          git fetch --tags origin
+          if git rev-parse --verify "refs/tags/$VERSION" >/dev/null 2>&1; then
+            echo "::notice::태그 $VERSION 이 이미 존재합니다 → 릴리즈 생성만 시도합니다."
+            echo "tag_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag_exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify SHA is an ancestor of main
+        run: |
+          set -euo pipefail
+          SHA='${{ steps.meta.outputs.sha }}'
+          if ! git merge-base --is-ancestor "$SHA" origin/main; then
+            echo "::error::SHA $SHA 가 origin/main 에 포함되지 않음 → 태그 거부"
+            exit 1
+          fi
+
+      - name: Fetch release notes (PR body)
+        id: notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ steps.meta.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          gh pr view "$PR_NUM" --json body --jq '.body' > /tmp/release-notes.md
+          if [ ! -s /tmp/release-notes.md ]; then
+            echo "::error::PR #$PR_NUM 본문이 비어 있음 → 릴리즈 노트 필수 (게이트 실패)"
+            exit 1
+          fi
+          echo "path=/tmp/release-notes.md" >> "$GITHUB_OUTPUT"
+
+      - name: Create annotated tag
+        if: steps.tag_guard.outputs.tag_exists != 'true'
+        run: |
+          set -euo pipefail
+          VERSION='${{ steps.meta.outputs.version }}'
+          SHA='${{ steps.meta.outputs.sha }}'
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git tag -a "$VERSION" "$SHA" -m "릴리즈 $VERSION"
+          git push origin "$VERSION"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.meta.outputs.version }}
+          SHA: ${{ steps.meta.outputs.sha }}
+        run: |
+          set -euo pipefail
+          # 이미 존재하면 본문만 갱신, 없으면 새로 생성 (idempotent)
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "::notice::Release $VERSION 이 이미 존재 → 본문 갱신"
+            gh release edit "$VERSION" \
+              --title "$VERSION" \
+              --notes-file /tmp/release-notes.md
+          else
+            gh release create "$VERSION" \
+              --target "$SHA" \
+              --title "$VERSION" \
+              --notes-file /tmp/release-notes.md
+          fi
+
+      - name: Summary
+        run: |
+          VERSION='${{ steps.meta.outputs.version }}'
+          SHA='${{ steps.meta.outputs.sha }}'
+          {
+            echo "## 릴리즈 퍼블리시 완료"
+            echo ""
+            echo "- 버전: \`$VERSION\`"
+            echo "- 커밋: \`$SHA\`"
+            echo "- 트리거: \`${{ github.event_name }}\`"
+            echo "- PR: #${{ steps.meta.outputs.pr_number }}"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## 배경

v1.0.0(#15) 이 main 에 머지됐지만 **태그와 GitHub Release 가 생성되지 않았다.** 원인은 릴리즈 절차 중 태그/Release 생성 단계가 사람(또는 에이전트)의 수동 작업에 의존해 있었고, 누락되어도 검출되지 않는 구조였기 때문.

이 PR 은 해당 단계를 **GitHub Actions 로 옮겨 PR 머지 이벤트에 자동 발화**하도록 만든다. 누락을 구조적으로 차단하고, 실패 시 `workflow_dispatch` 로 재실행할 수 있게 만든다.

## 변경 요약

### 1. 새 워크플로: `.github/workflows/release-publish.yml`

- 트리거
  - `pull_request_target` (closed, base=main) — `merged == true` AND 제목이 `release:` 또는 `hotfix:` prefix
  - `workflow_dispatch` — 수동 실행용 (소급 태깅·실패 복구)
- 작업
  1. PR 제목에서 `vX.Y.Z` 추출 + 형식 검증
  2. 머지 SHA 가 `origin/main` 조상인지 검증
  3. PR 본문을 릴리즈 노트로 사용 (비면 실패)
  4. annotated 태그 생성 + push
  5. `gh release create` / 이미 있으면 `gh release edit` (idempotent)
- 안전장치: 최소 권한(`contents: write`, `pull-requests: read`), 태그/Release 양쪽 idempotent, 태그·Release 삭제는 수행하지 않음

### 2. 문서 정비

- `.claude/plans/deployment-plan.md` — § "CI 자동화" 신설, 정규/핫픽스 플로우 단계 갱신, 소급 적용 방법 명시
- `.claude/commands/release.md` — §8 을 "워크플로 완료 확인 + 실패 복구" 로 교체, 수동 `git tag`/`gh release create` 금지 명시, PR 제목 형식 필수화
- `.claude/commands/hotfix.md` — §6 을 워크플로 확인으로 교체, 동일 금지 규칙 추가
- `.claude/rules/git-flow.md` — 릴리즈 플로우 요약에 워크플로 단계 반영

## v1.0.0 소급 적용 계획

이 PR 이 머지되면 main 에 워크플로가 존재하게 된다. 그 후 다음 명령으로 v1.0.0 에 대한 태그/Release 를 소급 생성한다.

```bash
gh workflow run release-publish.yml \\
  -f version=v1.0.0 \\
  -f sha=65becee00f65c4943853b424e8dd2c713b8f6628 \\
  -f pr_number=15
```

- `sha` = #15 머지 커밋
- `pr_number=15` → 워크플로가 #15 의 본문을 읽어 Release 노트로 사용

## 리뷰 포인트

- **트리거 필터**: release/* 브랜치에서 올라오는 비릴리즈 PR (이 PR 처럼 `ci:` prefix) 은 자동 실행 대상이 아니다. 제목 prefix (`release:` / `hotfix:`) 로 릴리즈 PR 을 구분한다.
- **pull_request_target 선택**: closed 이벤트 처리를 위해 base 브랜치의 워크플로 파일을 쓰는 `pull_request_target` 을 사용. 최소 권한만 부여해 보안 리스크 최소화.
- **백머지 제외**: develop back-merge 는 충돌 가능성 때문에 이번 스코프에서 자동화하지 않았다. `/release`·`/hotfix` 커맨드가 계속 담당.
- **Idempotency**: 태그가 이미 있으면 태그 생성은 스킵하고 Release 본문만 갱신한다. `workflow_dispatch` 재실행이 안전.

## 체크리스트

- [x] 워크플로 YAML 문법 검증
- [x] `release:` / `hotfix:` 이외 제목은 필터에서 제외되도록 `if` 조건 작성
- [x] PR 본문 비어 있으면 게이트 실패로 중단
- [x] SHA ancestor 검증으로 잘못된 커밋에 태그 찍히는 것 방지
- [x] 태그·Release 둘 다 idempotent

## 머지 후 작업

1. 이 PR 머지 (자동 워크플로 대상 아님 — 제목이 `ci:` prefix)
2. `gh workflow run release-publish.yml -f version=v1.0.0 -f sha=65becee... -f pr_number=15\` 로 v1.0.0 소급 퍼블리시
3. `gh run watch` 로 성공 확인
4. `gh release view v1.0.0` 로 Release 공개 확인
5. release/v1.0.0 → develop back-merge (버전 bump 동기화는 v1.0.0 릴리즈 당시 `chore: vX.Y.Z 릴리즈 준비` 커밋이 있었는지 확인하고 처리)

🤖 Generated with [Claude Code](https://claude.com/claude-code)